### PR TITLE
Fix OpenCV error "operands could not be broadcast together with shapes"

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -59,12 +59,18 @@ def harambify(img_file):
         harambe_x_offset = int(round((harambe_width - w) / 2))
         harambe_res = cv2.resize(img_harambe, (harambe_width, harambe_height))
 
-        # print(harambe_res)
+        # print("current_face.y: {}".format(y))
+        # print("current_face.x: {}".format(x))
+        # print("current_face.h: {}".format(h))
+        # print("current_face.w: {}".format(w))
 
-        (h, w) = harambe_res.shape[:2]
-        print(h)
-        print(w)
-        print("")
+        (harambe_res_h, harambe_res_w) = harambe_res.shape[:2]
+        # print("harambe_res.h: {}".format(harambe_res_h))
+        # print("harambe_res.w: {}".format(harambe_res_w))
+
+        (img_h, img_w) = img.shape[:2]
+        # print("img.h: {}".format(img_h))
+        # print("img.w: {}".format(img_w))
 
         # TODO: bound the Harambe replacement rectangle to the dimensions of the photo -- it's unclear what will happen if a face is detected at the edge of a photo, but likely the app will crash.
 
@@ -74,20 +80,38 @@ def harambify(img_file):
             harambe_y2 = harambe_y1 + harambe_height
             harambe_x1 = x - harambe_x_offset
             harambe_x2 = harambe_x1 + harambe_width
-            print(harambe_height)
-            print(harambe_width)
-            print("")
-            print(harambe_y_offset)
-            print(harambe_x_offset)
-            print("")
-            print(harambe_y1)
-            print(harambe_y2)
-            print(harambe_x1)
-            print(harambe_x2)
-            img[harambe_y1:harambe_y2, harambe_x1:harambe_x2, c] = harambe_res[:, :, c] * \
-                                   (harambe_res[:, :, 3] / 255.0) + \
+
+            harambe_clip_top = 0
+            if harambe_y1 < 0:
+              harambe_clip_top = abs(harambe_y1)
+            harambe_clip_bottom = 0
+            if harambe_y2 > img_h:
+              harambe_clip_bottom = abs(harambe_y1 + harambe_height - img_h)
+            harambe_clip_left = 0
+            if harambe_x1 < 0:
+              harambe_clip_left = abs(harambe_x1)
+            harambe_clip_right = 0
+            if harambe_x2 > img_w:
+              harambe_clip_right = abs(harambe_x1 + harambe_width - img_w)
+
+            harambe_y1 = max(harambe_y1, 0)
+            harambe_y2 = min(harambe_y2, img_h)
+            harambe_x1 = max(harambe_x1, 0)
+            harambe_x2 = min(harambe_x2, img_w)
+
+            # print("harambe_height: {}".format(harambe_height))
+            # print("harambe_width: {}".format(harambe_width))
+            # print("harambe_y_offset: {}".format(harambe_y_offset))
+            # print("harambe_x_offset: {}".format(harambe_x_offset))
+            # print("harambe_y1: {}".format(harambe_y1))
+            # print("harambe_y2: {}".format(harambe_y2))
+            # print("harambe_x1: {}".format(harambe_x1))
+            # print("harambe_x2: {}".format(harambe_x2))
+
+            img[harambe_y1:harambe_y2, harambe_x1:harambe_x2, c] = harambe_res[harambe_clip_top:harambe_height-harambe_clip_bottom, harambe_clip_left:harambe_width-harambe_clip_right, c] * \
+                                   (harambe_res[harambe_clip_top:harambe_height-harambe_clip_bottom, harambe_clip_left:harambe_width-harambe_clip_right, 3] / 255.0) + \
                                    img[harambe_y1:harambe_y2, harambe_x1:harambe_x2, c] * \
-                                   (1.0 - (harambe_res[:, :, 3] / 255.0))
+                                   (1.0 - (harambe_res[harambe_clip_top:harambe_height-harambe_clip_bottom, harambe_clip_left:harambe_width-harambe_clip_right, 3] / 255.0))
 
     # Write the file if there is at least one face
     n_faces = len(faces)
@@ -182,17 +206,6 @@ def handle_start_help(m):
 def lambda_handler(event, context):
 
   logger.info("lambda_handler triggered")
-
-  # logger.info("sometging")
-  # bot.process
-
-  # pp = pprint.PrettyPrinter(indent=4)
-  # pp.pprint(event)
-
-  # logger.info('got event{}'.format(event))
-  # logger.error('something went wrong')
-
-  # dumpclean(event)
 
   if "body" in event:
     logger.info(event["body"])

--- a/lambda.py
+++ b/lambda.py
@@ -54,16 +54,39 @@ def harambify(img_file):
     for (x, y, w, h) in faces:
         # Resize the harambe according to the face. Maintain harambe_img_ratio ratio of width:height
         harambe_height = int(round(w / harambe_img_ratio * harambe_scale_adjustment))
-        harambe_y_offset = int(abs(harambe_height - h) / 2)
+        harambe_y_offset = int(round((harambe_height - h) / 2))
         harambe_width = int(round(w * harambe_scale_adjustment))
-        harambe_x_offset = int(abs(harambe_width - w) / 2)
+        harambe_x_offset = int(round((harambe_width - w) / 2))
         harambe_res = cv2.resize(img_harambe, (harambe_width, harambe_height))
+
+        # print(harambe_res)
+
+        (h, w) = harambe_res.shape[:2]
+        print(h)
+        print(w)
+        print("")
+
+        # TODO: bound the Harambe replacement rectangle to the dimensions of the photo -- it's unclear what will happen if a face is detected at the edge of a photo, but likely the app will crash.
 
         # Copy the resided harambe over the face keeping the alpha channel
         for c in range(0, 3):
-            img[y-harambe_y_offset:y+harambe_height-harambe_y_offset, x-harambe_x_offset:x+harambe_width-harambe_x_offset, c] = harambe_res[:, :, c] * \
+            harambe_y1 = y - harambe_y_offset
+            harambe_y2 = harambe_y1 + harambe_height
+            harambe_x1 = x - harambe_x_offset
+            harambe_x2 = harambe_x1 + harambe_width
+            print(harambe_height)
+            print(harambe_width)
+            print("")
+            print(harambe_y_offset)
+            print(harambe_x_offset)
+            print("")
+            print(harambe_y1)
+            print(harambe_y2)
+            print(harambe_x1)
+            print(harambe_x2)
+            img[harambe_y1:harambe_y2, harambe_x1:harambe_x2, c] = harambe_res[:, :, c] * \
                                    (harambe_res[:, :, 3] / 255.0) + \
-                                   img[y-harambe_y_offset:y+harambe_height-harambe_y_offset, x-harambe_x_offset:x+harambe_width-harambe_x_offset, c] * \
+                                   img[harambe_y1:harambe_y2, harambe_x1:harambe_x2, c] * \
                                    (1.0 - (harambe_res[:, :, 3] / 255.0))
 
     # Write the file if there is at least one face
@@ -99,7 +122,7 @@ def handle_photo(m):
         logger.info("No f_id -- that's odd!")
         return
 
-    logger.info("Photos found in message: party time?")
+    logger.info("Photo(s) found in message: party time?")
 
     # Download and write the file
     f_info = bot.get_file(f_id)


### PR DESCRIPTION
Certain photos cause the following to be logged in CloudWatch:

```
operands could not be broadcast together with shapes (700,542) (760,542) : ValueError
Traceback (most recent call last):
File "/var/task/lambda.py", line 200, in lambda_handler
handle_photo(update.message)
File "/var/task/lambda.py", line 138, in handle_photo
n_faces = harambify(filepath)
File "/var/task/lambda.py", line 90, in harambify
(1.0 - (harambe_res[:, :, 3] / 255.0))
ValueError: operands could not be broadcast together with shapes (700,542) (760,542) 
```

Intuitively, it seems that there's some mismatch in the size of the space that we're trying to paste the Harambe face image into (specifically, the height 700 doesn't match 760); however, I can't seem to identify which piece of the code is causing this mismatch, as the heights I observe through the logs introduced in this branch seem to be 760 (and I can't figure out where the 700 is coming from).

```python
print(harambe_height) # 760
print(harambe_width) # 542
print(harambe_y_offset) # 199
print(harambe_x_offset) # 90
print(harambe_y1) # 260
print(harambe_y2) # 1020
print(harambe_x1) # 453
print(harambe_x2) # 995
```

For reference, here is an example of a message update HTTP request body that causes this issue:

```
{
    "update_id": 711723893,
    "message": {
        "message_id": 4216,
        "from": {
            "id": 76910859,
            "first_name": "Jon",
            "last_name": "Sibley"
        },
        "chat": {
            "id": 76910859,
            "first_name": "Jon",
            "last_name": "Sibley",
            "type": "private"
        },
        "date": 1479839045,
        "forward_from": {
            "id": 205627253,
            "first_name": "Hugh"
        },
        "forward_date": 1479837575,
        "photo": [
            {
                "file_id": "AgADAQADJKgxG3WfQQxMEHtme82naGu95y8ABGhdhJCxzDk6VR4CAAEC",
                "file_size": 1627,
                "file_path": "photo/file_116.jpg",
                "width": 90,
                "height": 67
            },
            {
                "file_id": "AgADAQADJKgxG3WfQQxMEHtme82naGu95y8ABJm2hMBfxLuYVh4CAAEC",
                "file_size": 21121,
                "width": 320,
                "height": 240
            },
            {
                "file_id": "AgADAQADJKgxG3WfQQxMEHtme82naGu95y8ABN63mKfq38FhVx4CAAEC",
                "file_size": 87747,
                "width": 800,
                "height": 600
            },
            {
                "file_id": "AgADAQADJKgxG3WfQQxMEHtme82naGu95y8ABJeZkUfQtTBoVB4CAAEC",
                "file_size": 140289,
                "file_path": "photo/file_117.jpg",
                "width": 1280,
                "height": 960
            }
        ]
    }
}
```